### PR TITLE
Stop bitcoind before stopping its container

### DIFF
--- a/switch.sh
+++ b/switch.sh
@@ -85,6 +85,7 @@ switch_on_sync_done() {
 	sed -i "s/dbcache=.*/dbcache=200/g;" /bitcoin/bitcoin.conf
 
 	echo "Restarting Bitcoin"
+	docker exec  "$BITCOIN_CONTAINER_NAME" bitcoin-cli stop
 	docker stop  "$BITCOIN_CONTAINER_NAME"
 	docker start "$BITCOIN_CONTAINER_NAME"
 


### PR DESCRIPTION
Fixes users getting stuck on the loading screen because bitcoind was rolling forward after IBD. This stops bitcoind properly to avoid running into this issue.

@lukechilds Would be great if this got in 0.3.9